### PR TITLE
forgot A12X iPad offsets

### DIFF
--- a/noncereboot1131UI/exploit/voucher_swap/parameters.c
+++ b/noncereboot1131UI/exploit/voucher_swap/parameters.c
@@ -131,6 +131,7 @@ initialize_computed_offsets() {
 static struct initialization offsets[] = {
 	{ "iPhone11,*", "16A366-16C104", offsets__iphone11_8__16C50  },
 	{ "iPhone10,1", "16A366-16C101", offsets__iphone10_1__16B92  },
+	{ "iPad8,*", "16B92-16C50", offsets__iphone11_8__16C50  },
     { "*",          "*",            offsets__iphone10_1__16B92 },
 	{ "*",          "*",            initialize_computed_offsets },
 };


### PR DESCRIPTION
should be the end for the offsets for all A9-A12 devices (maybe even A7-A8?)